### PR TITLE
Updated package reqs and removed some dependencies from setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ matplotlib
 pandas
 autograd
 assimulo
+cyipopt
+coverage

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup, find_packages
 
 setuptools_kwargs = {
     'zip_safe': False,
-    'install_requires': ['pyomo',
-                         'coverage',
+    'install_requires': ['coverage',
                          'numpy',
                          'scipy',
                          'pandas',
-                         'assimulo'],
+                         'assimulo',
+                         'cyipopt'],
     'scripts': [],
     'include_package_data': True
 }


### PR DESCRIPTION
Added cyipopt and coverage to package dependencies in the requirements.txt file. Removed Pyomo and added cyipopt to list of dependencies in the setup.py file. Installation runs fine and is working without any extra "conda install" statements besides:

conda install --file requireiments.txt


Also, the command:

python setup.py develop

still requires Cython installation for some reason... Look into this later?