### PR TITLE
Removed print statement in Commons.py. Additionally, a clip procedure…

### DIFF
--- a/PharmaPy/Commons.py
+++ b/PharmaPy/Commons.py
@@ -114,8 +114,6 @@ def handle_events(solver, event_info, state_event_list, any_event=True):
     idx_state = [[ind] * num for ind, num in enumerate(dim_events)]
     idx_state = np.hstack(idx_state)
 
-    print(idx_state)
-
     for ind, val in enumerate(event_markers):
         direction = state_event_list[idx_state[ind]].get('direction')
         terminate = False

--- a/PharmaPy/Interpolation.py
+++ b/PharmaPy/Interpolation.py
@@ -168,6 +168,8 @@ class PiecewiseLagrange:
             k = np.searchsorted(self.time_k, time_eval, side='right')
             k = np.minimum(self.num_interv, k)
 
+        k = np.clip(k, 1, self.num_interv)
+
         # ---------- Time normalization
         tau_k = (time_eval - time_k[k - 1]) / (time_k[k] - time_k[k - 1])
         tau_k = tau_k[..., np.newaxis]


### PR DESCRIPTION
… was added to the PiecewiseLagrange class to avoid indexing problems at the edges of the time domain.

This is a follow up from Dan's comments. I'll merge right away.