### PR TITLE
Holding Tank bug fix and Dryer bug fix

### DIFF
--- a/PharmaPy/Crystallizers.py
+++ b/PharmaPy/Crystallizers.py
@@ -1975,13 +1975,15 @@ class MSMPR(_BaseCryst):
             
             rho_solid = self.Solid_1.getDensity()
             vol_solid = dp['mu_n'][-1, 3] * self.Solid_1.kv
+            mass_solid = rho_solid*vol_solid
+
 
             vol_slurry = vol_solid + vol_liq
 
             if self.method == '1D-FVM':
                 distrib_tilde = dp['total_distrib'][-1]
                 self.Solid_1.updatePhase(distrib=distrib_tilde,
-                                         mass= mass_solid))
+                                         mass= mass_solid)
 
                 self.Slurry = Slurry()
 

--- a/PharmaPy/Drying_Model.py
+++ b/PharmaPy/Drying_Model.py
@@ -79,7 +79,7 @@ class Drying:
 
         # Limiting factor
         if eta_fun is None:
-            eta_fun = lambda sat, mass_frac: 1
+            eta_fun = lambda sat, mass_frac: np.ones_like(sat)
 
         self.eta_fun = eta_fun
         self.mass_eta = mass_eta
@@ -260,7 +260,7 @@ class Drying:
             sat_eta = satur
             w_eta = x_liq
 
-        limiter_factor = self.eta_fun(sat_eta)#, w_eta)
+        limiter_factor = self.eta_fun(sat_eta, w_eta)
 
         # Dry rate
         self.dry_rate = self.get_drying_rate(x_liq, temp_sol, y_gas,

--- a/PharmaPy/Phases.py
+++ b/PharmaPy/Phases.py
@@ -639,7 +639,8 @@ class VaporPhase(ThermoPhysicalManager):
         tref = self.tref_hvap[idx]
 
         watson = ((self.t_crit[idx] - temp) / (self.t_crit[idx] - tref))**0.38
-
+        if np.isnan(watson.flatten()).any():
+            raise ValueError("(self.t_crit[idx] - temp) / (self.t_crit[idx] - tref) was negative. Check property values")
         deltahvap = np.zeros(delta_shape)
 
         if num_temp > 1:


### PR DESCRIPTION
The semi-batch crystallizer had a syntax error as well as an undefined term for updating the crystallization. I defined the mass_solid as the vol_solid*rho_solid. There may have been a different way to resolve this. In the commit history, the form was very different, then was changed with the most recent update to be this non-functioning file. It's possible this file was modified by mistake on the most recent push and should be reverted to the previously stable file. This fix assumes the current file is the intended version. 
I also added an explicit error raise in the phases module that I discovered was the result of poor parameter data. This was a very difficult error to track down and thought it should be explicit in implementation. Finally, there were some modifications on line 263 in drying_model.py that appeared to have been commented out during debugging and never uncommented. I've uncommented and fixed the default eta_fun function to fit with the necessary shape.