### PR TITLE
Update installation instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ target/
 # pyenv
 *.python-version
 *.pyc
+__pycache__/
+*.pyo
+*.pyd
 
 # celery beat schedule file
 celerybeat-schedule
@@ -21,6 +24,8 @@ celerybeat-schedule
 .venv/
 venv/
 ENV/
+.conda/
+conda-meta/
 
 # Spyder project settings
 .spyderproject
@@ -80,5 +85,12 @@ ENV/
 *.zip
 *.tar.gz
 *.rar
+
+# Packaging artifacts
+*.egg-info/
+*.eggs/
+build/
+dist/
+pip-wheel-metadata/
 
 source/crystallization/

--- a/doc/online_docs/installation.rst
+++ b/doc/online_docs/installation.rst
@@ -25,7 +25,7 @@ Installation
 
 For installation, we recommend the use of conda environments to control packages dependencies and PharmaPy. A lighweight version of conda (`miniconda`_) is probably a good option for new users of the management system.
 
-For PharmaPy installation, you must use the source code, which is available in our `Github repository`_. Once the source code is downloaded to the desired location, navigate (:code:`cd`) to the directory which contains the setup.py file. Then, follow the instructions on the :code:`installation_guide.txt`, to setup fresh conda environment and install PharmaPy and its dependencies.
+For PharmaPy installation, you must use the source code, which is available in our `Github repository`_. Once the source code is downloaded to the desired location, navigate (:code:`cd`) to the directory which contains the setup.py file. Then, follow the instructions on the :code:`instal_instructions.txt`, to setup fresh conda environment and install PharmaPy and its dependencies.
 
 ..
         make sure your conda environment is appropriately installed and activated, then input the following commands for PharmaPy installation:

--- a/install_instructions.txt
+++ b/install_instructions.txt
@@ -16,7 +16,9 @@ Step 4: After this step, both PharmaPy dependencies and PharmaPy itself should b
 
 Step 5: Activate the new environment by doing: conda activate <name_of_environment> (exclude <>)
 
-Step 6: Test PharmaPy by moving to the tests/ directory (cd tests) and then running: python reactor_tests.py
+Step 6: Test PharmaPy by moving to the integration test directory and running:
+	cd tests/integration
+	python reactor_tests.py
 
 # ---------- Manual installation ----------
 Step 1: Create a conda environment named <env_name> (optional)
@@ -49,13 +51,17 @@ conda create --prefix <Directory address + /<env_name>>
 
 Step 2: Install the package requirements in requirements.txt
 
-conda install -c conda-forge --file requirements.txt
+conda install -c conda-forge --file requirements.txt -y
 
 Step 3: Install PharmaPy; navigate to the source directory
 
-python setup.py develop
+pip install -e .
 
-Step 4: Check to see if the package is working by running a test in tests/
+Step 4: Check to see if the package is working
+
+python -c "import PharmaPy; print('PharmaPy import OK')"
+cd tests/integration
+python reactor_tests.py
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages, Extension
+from setuptools import setup, find_packages
 
 # Read the content of requirements.txt into a list
 with open("requirements.txt", "r") as f:
@@ -11,5 +11,4 @@ setup(name='PharmaPy',
       author_email='dcasasor@purdue.edu',
       license='',
       url='',
-      py_modules=["PharmaPy"],
       install_requires=requirements)


### PR DESCRIPTION
**Description**

This PR updates installation guidance and packaging configuration to fix confusing/outdated instructions. These were the edits I performed locally to successfully install `PharmaPy`

**Changes**
- Updated `setup.py`
  - Removed `py_modules=["PharmaPy"]` so editable install resolves the package correctly.
  - Removed unused `Extension` import.
- Updated `install_instructions.txt`
  - Replaced deprecated `python setup.py develop` with `pip install -e .`.
  - Added `-y` for conda requirements install.
  - Corrected test instructions to run from `tests/integration`:
    - `cd tests/integration`
    - `python reactor_tests.py`
  - Added an explicit import smoke test:
    - `python -c "import PharmaPy; print('PharmaPy import OK')"`
- Updated `.gitignore`
  - Added common Python cache/build artifacts and local env/package metadata paths.

**Motivation**
- Previous install steps were outdated and could fail or confuse users.
- Packaging metadata conflicted with package discovery in editable installs.
- Test command path in instructions did not match repo layout.

**Validation**
- Created a clean conda env (`pharma-py`) and installed dependencies from `requirements.txt`.
- Installed PharmaPy in editable mode.
- Verified import works outside repo root.
- Ran integration test successfully from `tests/integration` (`reactor_tests.py`, 2 tests passing).