### PR TITLE
Fix Read the Docs build configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,20 +5,20 @@
 # Required
 version: 2
 
-# Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
-    # You can also specify other tool versions:
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
+    # Documentation-only build: runtime imports are mocked in conf.py
+    # (autodoc_mock_imports), so this Python only needs to satisfy the
+    # Sphinx toolchain in doc/requirements.txt (Sphinx 9 requires >= 3.12).
+    python: "3.13"
+  apt_packages:
+    # Required by nbsphinx to convert the example notebooks
+    - pandoc
 
 python:
   install:
-    - requirements: requirements.txt
-  system_packages: true
+    - requirements: doc/requirements.txt
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,9 @@
+# Documentation build dependencies (see .readthedocs.yaml).
+# Runtime packages (numpy, scipy, assimulo, ...) are intentionally not
+# installed: doc/online_docs/conf.py mocks them via autodoc_mock_imports,
+# and assimulo cannot be installed from PyPI without a SUNDIALS toolchain.
+# Versions pinned to the set verified to build this documentation.
+sphinx==9.1.0
+sphinx-rtd-theme==3.1.0
+nbsphinx==0.9.8
+sphinxcontrib-bibtex==2.7.0


### PR DESCRIPTION
The documentation at pharmapy.readthedocs.io has not updated since 2023. The reason is that Read the Docs removed support for the `python.system_packages` option that `.readthedocs.yaml` still uses, so every build now fails during configuration validation in about two seconds, before the repository is even checked out (see for example [build 29721876](https://app.readthedocs.org/projects/pharmapy/builds/29721876/)). The site therefore still serves the last successful build and none of the changes merged here since then are visible.

This PR makes the build work again:

- Remove the unsupported `python.system_packages` option.
- Install documentation dependencies from a new `doc/requirements.txt` instead of the runtime `requirements.txt`. The Sphinx configuration already mocks all runtime imports (`autodoc_mock_imports` in `doc/online_docs/conf.py`), so numpy/scipy/assimulo are not needed to build the docs, and `assimulo` cannot be pip-installed on Read the Docs anyway because it needs a SUNDIALS toolchain.
- Add `pandoc` through `apt_packages`; nbsphinx needs it to convert the example notebooks.
- Raise the build Python to 3.13 to satisfy current Sphinx.

I verified the result locally: a fresh virtual environment installed only from `doc/requirements.txt`, with pandoc on PATH, builds `doc/online_docs` successfully (60 warnings, none fatal; the notebooks are not executed since they have stored outputs). No documentation content is changed by this PR.

After merging, the next push should trigger a Read the Docs build automatically. If it does not, the webhook may need to be re-enabled from the Read the Docs dashboard by a project maintainer.
