### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,6 @@ build:
 python:
   install:
     - requirements: requirements.txt
-  system_packages: true
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Removing the deprecated Read the Docs logic schema for system_packages